### PR TITLE
feat: add git config file, install script

### DIFF
--- a/dotfiles/.gitconfig
+++ b/dotfiles/.gitconfig
@@ -1,0 +1,3 @@
+[core]
+    editor = vim
+    filemode = true

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,3 @@
+#! /bin/sh
+
+cp -a ./dotfiles/. ~/


### PR DESCRIPTION
Add a `.gitconfig` file to the project, which sets the default editor to vim, and configures Git to save mode information to the repository (this is useful when developing for GitHub Actions, for example, where code is executed directly by the runner after cloning the repo).

This commit also adds an install.sh script, which copies all files under the `dotfiles/` directory to the user's home directory.