### PR TITLE
feat: only allow fast-forward pulls with Git

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -33,6 +33,6 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2.1.5
         with:
-          node-version: 12
+          node-version: 16
       - name: Release
         run: npx semantic-release

--- a/dotfiles/.gitconfig
+++ b/dotfiles/.gitconfig
@@ -1,3 +1,6 @@
 [core]
     editor = vim
     filemode = true
+
+[pull]
+    ff = only


### PR DESCRIPTION
Prevent Git from creating merge commits when pulling from a remote repository by setting the pull.ff option to "only".

See https://bit.ly/3z78fBU for more details.